### PR TITLE
Don't prepend a UTF-8 BOM when downloading.

### DIFF
--- a/js/app/main.js
+++ b/js/app/main.js
@@ -193,7 +193,8 @@ requirejs({locale: navigator.language}, [
         ' ' + game.config.date
         : ''
       )
-      + '.ptn'
+      + '.ptn',
+      true
     );
   }).attr('title', t.Download);
 


### PR DESCRIPTION
There's no real advantage to a UTF-8 BOM (there's no byte order to
indicate), and it can break tools that aren't expecting it (for example,
Taktician's parser broke until I added support)