### PR TITLE
feat[analysis/db/games] filter by tournament, min-date, max-date

### DIFF
--- a/src/components/controls/DateInput.vue
+++ b/src/components/controls/DateInput.vue
@@ -1,0 +1,135 @@
+<template>
+  <q-input
+    v-show="!hidden"
+    v-model="modelValueProxy"
+    :label="label"
+    :rules="dateRules"
+    :readonly="readonly"
+    hide-bottom-space
+    clearable
+    filled
+    item-aligned
+  >
+    <template v-slot:prepend>
+      <q-icon :name="icon" />
+    </template>
+    <q-popup-proxy
+      v-if="!readonly"
+      v-model="showDatePicker"
+      @before-show="proxyDate = modelValueProxy"
+      anchor="center middle"
+      self="center middle"
+      transition-show="none"
+      transition-hide="none"
+      no-refocus
+    >
+      <div>
+        <q-date
+          v-model="proxyDate"
+          name="date"
+          mask="YYYY.MM.DD"
+          :text-color="primaryFG"
+          today-btn
+          :navigation-min-year-month="minDateString"
+          :navigation-max-year-month="maxDateString"
+          :options="dateOptionsFn"
+        >
+          <div class="row items-center justify-end q-gutter-sm">
+            <q-btn
+              :label="$t('Clear')"
+              @click="modelValueProxy = null"
+              flat
+              v-close-popup
+            />
+            <div class="col-grow" />
+            <q-btn :label="$t('Cancel')" flat v-close-popup />
+            <q-btn
+              :label="$t('OK')"
+              @click="modelValueProxy = proxyDate"
+              flat
+              v-close-popup
+            />
+          </div>
+        </q-date>
+      </div>
+    </q-popup-proxy>
+  </q-input>
+</template>
+
+<script>
+import { formats } from "../../Game/PTN/Tag";
+import { date } from "quasar";
+
+export default {
+  name: "DateInput",
+  props: {
+    value: String, // isoformat  date
+    label: String,
+    hidden: Boolean,
+    readonly: Boolean,
+    min: Date,
+    max: Date,
+    icon: {
+      type: String,
+      default: "date",
+    },
+  },
+  data() {
+    return {
+      proxyDate: null,
+      showDatePicker: false,
+      dateRules: [
+        (value) => !value || formats.date.test(value),
+        (value) =>
+          !value ||
+          !this.min ||
+          new Date(this.value) > this.min ||
+          `Must be after ${date.formatDate(this.min, "YYYY.MM")}`,
+        (value) =>
+          !value ||
+          !this.max ||
+          new Date(this.value) < this.max ||
+          `Must be before ${date.formatDate(this.max, "YYYY.MM")}`,
+      ],
+    };
+  },
+  computed: {
+    primaryFG() {
+      return this.$store.state.ui.theme.primaryDark ? "textLight" : "textDark";
+    },
+    minDateString() {
+      return this.min && date.formatDate(this.min, "YYYY/MM");
+    },
+    maxDateString() {
+      return this.max && date.formatDate(this.max, "YYYY/MM");
+    },
+    modelValueProxy: {
+      get() {
+        if (!this.value) return this.value;
+        return date.formatDate(Date.parse(this.value), "YYYY.MM.DD");
+      },
+      set(value) {
+        const parsedDate = this.parseDate(value);
+        this.$emit("input", parsedDate && parsedDate.toISOString());
+      },
+    },
+  },
+  methods: {
+    parseDate(str, separator = ".") {
+      if (!str) {
+        return null;
+      }
+      const [year, month, day] = str.split(separator);
+      return new Date(year, month - 1, day);
+    },
+    dateOptionsFn(dateStr) {
+      const parsedDate = this.parseDate(dateStr, "/");
+      return (
+        parsedDate &&
+        (!this.min || parsedDate > this.min) &&
+        (!this.max || parsedDate < this.max)
+      );
+    },
+  },
+};
+</script>

--- a/src/components/database/DatabaseGame.vue
+++ b/src/components/database/DatabaseGame.vue
@@ -17,7 +17,9 @@
     <q-item-section side>
       <Result :result="result" />
       <div class="q-mt-xs">
-        <q-icon v-if="tournament" name="event" right />
+        <q-icon v-if="tournament" name="event" right>
+          <tooltip>Tournament game</tooltip>
+        </q-icon>
         <span>
           <q-icon name="komi" class="q-mr-xs" />
           {{ komiString }}

--- a/src/components/drawers/Analysis.vue
+++ b/src/components/drawers/Analysis.vue
@@ -113,6 +113,10 @@
                   v-if="dbSettings.komi && dbSettings.komi.length"
                   name="komi"
                 />
+                <q-icon
+                  v-if="dbSettings.tournament != null"
+                  :name="dbSettings.tournament ? 'event' : 'event_outline'"
+                />
               </div>
             </q-item-label>
           </q-item-section>
@@ -219,6 +223,25 @@
             >
               <template v-slot:prepend>
                 <q-icon name="komi" />
+              </template>
+            </q-select>
+
+            <!-- Game type -->
+            <q-select
+              v-model="dbSettings.tournament"
+              :options="tournamentOptions"
+              emit-value
+              map-options
+              :label="$t('analysis.gameType')"
+              type="string"
+              item-aligned
+              clearable
+              filled
+            >
+              <template v-slot:prepend>
+                <q-icon
+                  :name="dbSettings.tournament ? 'event' : 'event_outline'"
+                />
               </template>
             </q-select>
 
@@ -331,6 +354,11 @@ export default {
       player2Index: null,
       player2Names: [],
       komiOptions: ["0", "0.5", "1", "1.5", "2", "2.5", "3", "3.5", "4"],
+      tournamentOptions: [
+        { label: this.$t("analysis.tournamentOptions.only"), value: true },
+        { label: this.$t("analysis.tournamentOptions.exclude"), value: false },
+        { label: this.$t("analysis.tournamentOptions.ignore"), value: null },
+      ],
       dbMinRating: 0,
       botSettings: { ...this.$store.state.ui.botSettings },
       dbSettings: { ...this.$store.state.ui.dbSettings },
@@ -491,6 +519,7 @@ export default {
         );
         const settings = {
           include_bot_games: this.dbSettings.includeBotGames,
+          tournament: this.dbSettings.tournament,
           white: this.dbSettings.player1 || null,
           black: this.dbSettings.player2 || null,
           min_rating,

--- a/src/components/drawers/Analysis.vue
+++ b/src/components/drawers/Analysis.vue
@@ -117,6 +117,8 @@
                   v-if="dbSettings.tournament != null"
                   :name="dbSettings.tournament ? 'event' : 'event_outline'"
                 />
+                <q-icon v-if="dbSettings.minDate" name="date_arrow_right" />
+                <q-icon v-if="dbSettings.maxDate" name="date_arrow_left" />
               </div>
             </q-item-label>
           </q-item-section>
@@ -245,6 +247,20 @@
               </template>
             </q-select>
 
+            <!-- Min/Max Dates -->
+            <DateInput
+              :label="$t('analysis.minDate')"
+              v-model="dbSettings.minDate"
+              :max="dbSettings.maxDate && new Date(dbSettings.maxDate)"
+              icon="date_arrow_right"
+            />
+            <DateInput
+              :label="$t('analysis.maxDate')"
+              v-model="dbSettings.maxDate"
+              :min="dbSettings.minDate && new Date(dbSettings.minDate)"
+              icon="date_arrow_left"
+            />
+
             <!-- Max Suggestions -->
             <q-input
               v-model.number="dbSettings.maxSuggestedMoves"
@@ -319,6 +335,7 @@
 <script>
 import AnalysisItem from "../database/AnalysisItem";
 import DatabaseGame from "../database/DatabaseGame";
+import DateInput from "../controls/DateInput";
 import Ply from "../../Game/PTN/Ply";
 import { deepFreeze, timestampToDate } from "../../utilities";
 import { omit } from "lodash";
@@ -332,7 +349,7 @@ const usernamesEndpoint = `${apiUrl}/players`;
 
 export default {
   name: "Analysis",
-  components: { AnalysisItem, DatabaseGame },
+  components: { AnalysisItem, DatabaseGame, DateInput },
   props: {
     game: Object,
     recess: Boolean,
@@ -365,6 +382,7 @@ export default {
       botSettingsHash: this.hashSettings(this.$store.state.ui.botSettings),
       dbSettingsHash: this.hashSettings(this.$store.state.ui.dbSettings),
       sections: { ...this.$store.state.ui.analysisSections },
+      testMinDate: "2023-06-17",
     };
   },
   computed: {
@@ -522,6 +540,8 @@ export default {
           tournament: this.dbSettings.tournament,
           white: this.dbSettings.player1 || null,
           black: this.dbSettings.player2 || null,
+          min_date: this.dbSettings.minDate,
+          max_date: this.dbSettings.maxDate,
           min_rating,
           komi,
           max_suggested_moves,

--- a/src/components/drawers/Analysis.vue
+++ b/src/components/drawers/Analysis.vue
@@ -536,6 +536,7 @@ export default {
             result: game.result,
             date: timestampToDate(game.date),
             komi: game.komi,
+            tournament: game.tournament,
           }))
         );
 

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -431,6 +431,12 @@ export default {
     "Top Games from Position": "Top Games from Position",
     visits: "1 visit | {count} visits",
     wins: "1 win | {count} wins",
+    gameType: "Game type",
+    tournamentOptions: {
+      only: "Tournament games only",
+      exclude: "Regular games only",
+      ignore: "All games",
+    },
   },
 
   format: {

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -431,6 +431,8 @@ export default {
     "Top Games from Position": "Top Games from Position",
     visits: "1 visit | {count} visits",
     wins: "1 win | {count} wins",
+    minDate: "Games after",
+    maxDate: "Games before",
     gameType: "Game type",
     tournamentOptions: {
       only: "Tournament games only",

--- a/src/icons.js
+++ b/src/icons.js
@@ -27,6 +27,8 @@ export default {
   copy: "mdi-content-copy",
   database: "mdi-database",
   database_add: "mdi-database-plus",
+  date_arrow_left: "mdi-calendar-arrow-left",
+  date_arrow_right: "mdi-calendar-arrow-right",
   date: "mdi-calendar",
   date_time: "mdi-calendar-clock",
   delete: "mdi-delete",

--- a/src/icons.js
+++ b/src/icons.js
@@ -37,6 +37,7 @@ export default {
   embed: "mdi-code-tags",
   error: "mdi-alert-circle",
   event: "mdi-trophy",
+  event_outline: "mdi-trophy-outline",
   file: "mdi-file",
   file_image: "mdi-file-image",
   first: "mdi-page-first",

--- a/src/store/ui/state.js
+++ b/src/store/ui/state.js
@@ -15,6 +15,9 @@ let defaults = {
     minRating: null,
     komi: [],
     maxSuggestedMoves: 8,
+    tournament: null,
+    minDate: null,
+    maxDate: null,
   },
   botSettings: {
     maxSuggestedMoves: 8,


### PR DESCRIPTION
Preview here: https://openings.exegames.de/

# tournament
- Fixed the tournament indicator on top games of a queried db position
  - <img width="143" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/1feb8f0f-08ab-4989-9f71-3245a436739a">

- added dropdown to filter by tournament/non-tournament/all games, which is reflected by mini-icons at the top
  - <img width="283" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/2498ce16-897d-4d0d-a596-21204932dc2d">
  - <img width="175" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/a3734f63-c4c6-42b2-8a7a-d284efb20f18"> `Tournament games only`
  - <img width="179" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/6f7d832d-9336-4e2c-ba61-ea73b4fe3bf9"> `Regular games only`
  - if `All games`  is selected,  no icon is displayed

# min-date, max-date
- Icon's displayed for active filters <img width="272" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/aceb3729-d205-4173-8cb7-fa7fd3f8ecd0">
- date inputs
<img width="334" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/4d08e0ea-13cd-4a79-ac94-b57012724458">
- Date picker's available dates are affected by the value of the other date input: 
<img width="320" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/62162057-b915-49bd-8f7d-deae7b6bca91">




