### PR TITLE
feat[Analysis Panel]: Automatically select the correct DB for the current board-size and search filters

### DIFF
--- a/src/components/drawers/Analysis.vue
+++ b/src/components/drawers/Analysis.vue
@@ -320,10 +320,10 @@
 
         <smooth-reflow class="relative-position">
           <q-item v-if="!databases.length" class="flex-center">
-            {{ $t("Loading DB list") }}
+            {{ $t("analysis.database.loading") }}
           </q-item>
           <q-item v-else-if="noMatchingDatabase" class="flex-center">
-            {{ $t("No DB available for the board size or search filters") }}
+            {{ $t("analysis.database.noMatchingOneFound") }}
           </q-item>
           <q-item v-else-if="!dbMoves.length" class="flex-center">
             {{ $t("None") }}
@@ -354,10 +354,10 @@
       >
         <smooth-reflow>
           <q-item v-if="!databases.length" class="flex-center">
-            {{ $t("Loading DB list") }}
+            {{ $t("analysis.database.loading") }}
           </q-item>
           <q-item v-else-if="noMatchingDatabase" class="flex-center">
-            {{ $t("No DB available for the board size or search filters") }}
+            {{ $t("analysis.database.noMatchingOneFound") }}
           </q-item>
           <q-item v-else-if="!dbGames.length" class="flex-center">
             {{ $t("None") }}

--- a/src/components/drawers/Analysis.vue
+++ b/src/components/drawers/Analysis.vue
@@ -319,7 +319,13 @@
         </smooth-reflow>
 
         <smooth-reflow class="relative-position">
-          <q-item v-if="!dbGames.length" class="flex-center">
+          <q-item v-if="!databases.length" class="flex-center">
+            {{ $t("Loading DB list") }}
+          </q-item>
+          <q-item v-else-if="noMatchingDatabase" class="flex-center">
+            {{ $t("No DB available for the board size or search filters") }}
+          </q-item>
+          <q-item v-else-if="!dbMoves.length" class="flex-center">
             {{ $t("None") }}
           </q-item>
           <AnalysisItem
@@ -347,7 +353,13 @@
         header-class="bg-accent"
       >
         <smooth-reflow>
-          <q-item v-if="!dbGames.length" class="flex-center">
+          <q-item v-if="!databases.length" class="flex-center">
+            {{ $t("Loading DB list") }}
+          </q-item>
+          <q-item v-else-if="noMatchingDatabase" class="flex-center">
+            {{ $t("No DB available for the board size or search filters") }}
+          </q-item>
+          <q-item v-else-if="!dbGames.length" class="flex-center">
             {{ $t("None") }}
           </q-item>
           <DatabaseGame
@@ -385,6 +397,7 @@ const apiUrl = "https://openings.exegames.de/api/v1";
 const bestMoveEndpoint = `${apiUrl}/best_move`;
 const openingsEndpoint = `${apiUrl}/opening`;
 const usernamesEndpoint = `${apiUrl}/players`;
+const databasesEndpoint = `${apiUrl}/databases`;
 
 export default {
   name: "Analysis",
@@ -413,6 +426,11 @@ export default {
       botMoves: [],
       dbMoves: [],
       dbGames: [],
+      /**
+       * List of available databases that can be queried by their index
+       * @type { {include_bot_games: bool, min_rating: number, size: number}[]] }
+       */
+      databases: [],
       player1Index: null,
       player1Names: [],
       player2Index: null,
@@ -457,6 +475,34 @@ export default {
       return Object.values(omit(this.dbSettings, "maxSuggestedMoves")).some(
         (setting) => setting !== null && (!isArray(setting) || setting.length)
       );
+    },
+    /**
+     * Select the ID of the database to use for the current board size and search filters
+     * @returns The ID of the best matching DB, `null` if there isn't any.
+     * board-size and include-bot-games are hard filters, min-rating is soft.
+     */
+    databaseIdToQuery() {
+      if (!this.databases.length) return null;
+
+      const dbsOfCorrectSize = this.databases.filter(
+        ({ size }) => size == this.game.config.size
+      );
+      const dbsMatchingBotFilter = dbsOfCorrectSize.filter(
+        ({ include_bot_games }) =>
+          include_bot_games || !this.dbSettings.includeBotGames
+      );
+
+      if (!dbsMatchingBotFilter.length) return null;
+      const bestMatchingDb = dbsMatchingBotFilter.reduce(
+        (a, b) => (a.min_rating < b.min_rating ? a : b),
+        dbsMatchingBotFilter[0]
+      );
+
+      if (!bestMatchingDb) return null;
+      return this.databases.indexOf(bestMatchingDb);
+    },
+    noMatchingDatabase() {
+      return this.databaseIdToQuery === null;
     },
   },
   methods: {
@@ -526,6 +572,10 @@ export default {
       this.player1Index = new Fuse(white);
       this.player2Index = new Fuse(black);
     },
+    async loadDatabases() {
+      const response = await fetch(databasesEndpoint);
+      this.databases = await response.json();
+    },
     searchPlayer1(query, update) {
       update(
         () =>
@@ -555,6 +605,8 @@ export default {
       );
     },
     async queryPosition() {
+      const databaseId = this.databaseIdToQuery;
+      if (databaseId === null) return;
       if (this.dbPosition && this.dbPosition[this.dbSettingsHash]) {
         return;
       }
@@ -568,7 +620,6 @@ export default {
         const uriEncodedTps = encodeURIComponent(tps);
 
         // DB Settings
-        const databaseId = 1 * this.dbSettings.includeBotGames;
         const min_rating =
           this.dbSettings.minRating === null
             ? 0
@@ -645,10 +696,12 @@ export default {
       }
     },
   },
-  mounted() {
+  async mounted() {
     if (this.isVisible) {
-      this.queryPosition();
       this.loadUsernames();
+      await this.loadDatabases();
+      // wait for databases to load before querying the position
+      this.queryPosition();
     }
   },
   watch: {

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -438,6 +438,11 @@ export default {
     },
     visits: "1 visit | {count} visits",
     wins: "win | wins",
+    database: {
+      loading: "Loading DB list",
+      noMatchingOneFound:
+        "No DB available for the board size or search filters",
+    },
   },
 
   format: {


### PR DESCRIPTION
To support multiple board sizes from the frontend, we need to use the correct URL depending on the size. Since the URLs are dynamic, that's a little more involved. This PR
- displays a message to the user if there is no DB matching the users board-size/query
- uses the right URL/DB if there is one available

## Explanation

Since the explorer backend now supports different board sizes (currently 5x5, 6x6, 7x7) we need a way to select the correct URL for the corresponding board size. There may be multiple DBs for one board-size (e.g. `6x6 - no bots - rating>1200` and `6x6 - bots - rating > 1700`) so that should influence our decision as well.

Since a list of available databases with their sizes, min_rating and whether they include bot games is available at `/databases` we first query that in `loadDatabases()` and then can use `databaseIdToQuery()` to determine which DB matches the board-size and filters best.

#### If no DB matching the board-size/filters was found:

![image](https://github.com/gruppler/PTN-Ninja/assets/8362046/3e3612df-cd51-4e9d-a5cf-86b7a4727798)


