### PR TITLE
feat[AnalysisPanel]: Tiltak move suggestions from AWS

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -442,6 +442,8 @@ export default {
     database: {
       loading: "Loading DB list",
       notFound: "No DB available for the current board size or search filters",
+      error: "Failed to load DBs",
+      newPosition: "No data for this position/settings",
     },
   },
 

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -421,6 +421,7 @@ export default {
     "analyzed positions":
       "No analyzed positions | 1 analyzed position | {count} analyzed positions",
     "Ask for suggestions": "Ask for suggestions",
+    "Ask for better suggestions": "Think harder",
     "Bot Moves": "Bot Suggestions",
     "Database Moves": "PlayTak History",
     gameType: "Game Type",


### PR DESCRIPTION
# Bot move suggestions

- Tiltak is running on AWS Lambda, accessible through the AWS Gateway API
  - API has slightly changed, I've updated the request body accordingly
  - API might still change in the future so consider this a preview that might break at any time
- Lambda is logging tps & komi
  - I'm not sure how long those logs persist and how long we need to keep them. There's probably a better approach by storing them in a DB

TilTak's strength can be changed through `time_control`. `FixedNodes` describes after how many visits the bot ends its search, so time is variable. Here it's preferable to be going by `Time` and give it `3 seconds` by default. After that search the user has the option to click `Think harder` and search again with an `8 seconds` budget.

Tiltak can also be asked to choose a single move with `action: "SuggestMove"`. If one was playing against it one could use the following setting for TilTak to independently choose how much time it uses. *This may not work well with the low AWS Lambda timeout.*
```js
{
  // ..
  time_control:
  {
    Time: [
      { secs: timeLeftOnTheClock, nanos: 0 },
      { secs: increment, nanos: 0 },
    ],
  }
}
```

### This AWS Lambda function currently times out after `15 seconds`

![image](https://github.com/gruppler/PTN-Ninja/assets/8362046/a696f143-55e2-4a56-93ea-24bbee6804fc)

# Improvements around opening databases:
## Better error handling
### Database-list couldn't be fetched
![image](https://github.com/gruppler/PTN-Ninja/assets/8362046/a44bfafd-32d5-4c83-a46b-d51c2211e64d)

### No moves available for the current position/settings
![image](https://github.com/gruppler/PTN-Ninja/assets/8362046/af29788c-b4eb-4cc1-8753-d20483af7072)

