### PR TITLE
feat[AnalysisPanel] Expand moves-panels when their settings are expanded

### DIFF
--- a/src/components/drawers/Analysis.vue
+++ b/src/components/drawers/Analysis.vue
@@ -16,7 +16,7 @@
           </q-item-section>
           <q-item-section side>
             <q-btn
-              @click.stop="showBotSettings = !showBotSettings"
+              @click.stop="toggleBotSettings"
               icon="settings"
               :color="showBotSettings ? 'primary' : ''"
               dense
@@ -176,7 +176,7 @@
           </q-item-section>
           <q-item-section side>
             <q-btn
-              @click.stop="showDBSettings = !showDBSettings"
+              @click.stop="toggleDBSettings"
               icon="settings"
               :color="showDBSettings ? 'primary' : ''"
               dense
@@ -549,6 +549,20 @@ export default {
     },
   },
   methods: {
+    toggleBotSettings() {
+      this.showBotSettings = !this.showBotSettings;
+      // Expand panel with settings if the panel was collapsed
+      if (this.showBotSettings) {
+        this.sections.botSuggestions = true;
+      }
+    },
+    toggleDBSettings() {
+      this.showDBSettings = !this.showDBSettings;
+      // Expand panel with settings if the panel was collapsed
+      if (this.showDBSettings) {
+        this.sections.dbMoves = true;
+      }
+    },
     hashSettings(settings) {
       return Object.values(settings).join(",");
     },
@@ -724,7 +738,6 @@ export default {
           return this.notifyError("HTTP-Error: " + response.status);
         }
         const data = await response.json();
-        console.log(data);
 
         const dbMoves = deepFreeze(
           data.moves.map((move, id) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,9 +3895,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001400:
-  version "1.0.30001442"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz#40337f1cf3be7c637b061e2f78582dc1daec0614"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+  version "1.0.30001512"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz"
+  integrity sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==
 
 cardinal@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Previously, when a moves panel was collapsed, clicking the settings would internally expand the settings-panel, but because the moves panel is still collapsed, nothing changes visually.

Now, clicking the gear icon on a collapsed panel
<img width="108" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/f7bd3e19-3cfc-4bb2-9c8a-e204d5011475"> opens the panel as well 
<img width="306" alt="image" src="https://github.com/gruppler/PTN-Ninja/assets/8362046/2c4119de-30e7-488d-9e25-2b89c7a6e286">
